### PR TITLE
Tighten up the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,64 @@
 templates/_compile
 vendor/smarty/smarty/.svn/
+
+### IntelliJ IDEs ###
+/.idea
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*


### PR DESCRIPTION
This will stop random stuff getting committed. 

Most notably I’ve added the .idea directory, which will stop contributors’ copies of PHPStorm from adding a bunch of meta files into the repo.

**Let's wait until we decide what to do with the `develop` branch before we merge this.**