### PR TITLE
Allow setup_info to be used on nginx

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -40,7 +40,7 @@ $variables['is_admin'] = false;
 $variables['module'] = null;
 $variables['title'] = $langvars['l_admin_title'];
 
-if ($swordfish == \Tki\SecureConfig::ADMINPW)
+if ($swordfish == \Tki\SecureConfig::ADMIN_PASS)
 {
     $i = 0;
     $variables['is_admin'] = true;

--- a/classes/Db.php
+++ b/classes/Db.php
@@ -44,13 +44,13 @@ class Db
 
     public function initDb($db_layer)
     {
-        $db_port = \Tki\SecureConfig::PORT;
-        $db_host = \Tki\SecureConfig::HOST;
-        $db_user = \Tki\SecureConfig::USER;
-        $db_pwd = \Tki\SecureConfig::PASS;
-        $db_name = \Tki\SecureConfig::NAME;
-        $db_type = \Tki\SecureConfig::TYPE;
-        $db_prefix = \Tki\SecureConfig::PREFIX;
+        $db_port = \Tki\SecureConfig::DB_PORT;
+        $db_host = \Tki\SecureConfig::DB_HOST;
+        $db_user = \Tki\SecureConfig::DB_USER;
+        $db_pwd = \Tki\SecureConfig::DB_PASS;
+        $db_name = \Tki\SecureConfig::DB_NAME;
+        $db_type = \Tki\SecureConfig::DB_TYPE;
+        $db_prefix = \Tki\SecureConfig::DB_TABLE_PREFIX;
 
         if ($db_layer == 'adodb')
         {

--- a/config/SecureConfig.php
+++ b/config/SecureConfig.php
@@ -21,38 +21,67 @@
 
 namespace Tki;
 
+/**
+ * Stores configuration details that are accessed across the entire codebase.
+ *
+ * NOTES: The ADOdb db module is currently required to run TKI. You can find it at http://php.weblogs.com/ADODB.
+ * Adodb is automatically configured to be run from vendor/adodb. We are migrating away from adodb, switching
+ * to pure PDO instead.
+ */
 class SecureConfig
 {
-    // The ADOdb db module is currently required to run TKI. You can find it at http://php.weblogs.com/ADODB.
-    // Adodb is automatically configured to be run from vendor/adodb.
-    // We are migrating away from adodb, switching to pure PDO instead.
+    /**
+     * Port to connect to database on.
+     *
+     * If you do not know the port, set this to '' for default.
+     * - MySQL default is 3306
+     * - PgSQL default is 5432
+     */
+    const DB_PORT = null;
 
-    // Port to connect to database on. Note : if you do not know the port, set this to '' for default.
-    // Ex, MySQL default is 3306, PgSQL is 5432
-    const PORT = null;
+    /**
+     * Hostname of the database server.
+     */
+    const DB_HOST = '127.0.0.1';
 
-    // Hostname of the database server:
-    const HOST = '127.0.0.1';
+    /**
+     * Username connect to the database.
+     */
+    const DB_USER = 'tki';
 
-    // Username and password to connect to the database:
-    const USER = 'tki';
-    const PASS = 'tki';
+    /**
+     * Password to connect to the database.
+     */
+    const DB_PASS = 'tki';
 
-    // Name of the SQL database:
-    const NAME = 'tki';
+    /**
+     * Name of the SQL database.
+     */
+    const DB_NAME = 'tki';
 
-    // Type of the SQL database.
-    // "mysqli" for MySQLi - needed for transaction support or "postgres9" for PostgreSQL ver 9 and up
-    // NOTE: only mysqli works as of this release.
-    const TYPE = 'mysqli';
-    // const TYPE = 'postgres9';
+    /**
+     * Type of the SQL database.
+     *
+     * Possible values:
+     * - "mysqli" -  required for transaction support.
+     * - "postgres9" - Version 9+.
+     *
+     * NOTES:
+     * - MySQLi is required for transaction support.
+     * - Only mysqli works as of this release.
+     */
+    const DB_TYPE = 'mysqli';
 
-    // Table prefix for the database. If you want to run more than
-    // one game of TKI on the same database, or if the current table
-    // names conflict with tables you already have in your db, you will
-    // need to change this
-    const PREFIX = 'tki_';
+    /**
+     * Table prefix for the database.
+     *
+     * If you want to run more than one game of TKI on the same database, or if the current table names
+     * conflict with tables you already have in your db, you will need to change this.
+     */
+    const DB_TABLE_PREFIX = 'tki_';
 
-    // Define the admin password, used for accessing create_universe, scheduler, and the admin control panel
-    const ADMINPW = 'secret';
+    /**
+     * Define the admin password, used for accessing "create_universe", "scheduler", and the admin control panel.
+     */
+    const ADMIN_PASS = 'secret';
 }

--- a/create_universe.php
+++ b/create_universe.php
@@ -44,7 +44,7 @@ if ($swordfish === null || $swordfish === false) // If no swordfish password has
     $step = "1";
 }
 
-if (($swordfish !== false) && (\Tki\SecureConfig::ADMINPW != $swordfish)) // If a swordfish password is not null and it does not match (bad pass), redirect to step 1 (default or 0.php)
+if (($swordfish !== false) && (\Tki\SecureConfig::ADMIN_PASS != $swordfish)) // If a swordfish password is not null and it does not match (bad pass), redirect to step 1 (default or 0.php)
 {
     $variables['goodpass'] = false;
     include_once 'create_universe/0.php';

--- a/create_universe/30.php
+++ b/create_universe/30.php
@@ -39,9 +39,9 @@ $variables['initbcommod']            = filter_input(INPUT_POST, 'initbcommod', F
 $variables['fedsecs']                = filter_input(INPUT_POST, 'fedsecs', FILTER_SANITIZE_NUMBER_INT);
 $variables['loops']                  = filter_input(INPUT_POST, 'loops', FILTER_SANITIZE_NUMBER_INT);
 $variables['swordfish']              = filter_input(INPUT_POST, 'swordfish', FILTER_SANITIZE_URL);
-$variables['drop_tables_results']    = Tki\Schema::dropTables($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::TYPE); // Delete all tables in the database
+$variables['drop_tables_results']    = Tki\Schema::dropTables($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::DB_TYPE); // Delete all tables in the database
 $variables['drop_tables_count']      = count($variables['drop_tables_results']) - 1;
-$variables['drop_seq_results']       = Tki\Schema::dropSequences($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::TYPE); // Delete all sequences in the database
+$variables['drop_seq_results']       = Tki\Schema::dropSequences($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::DB_TYPE); // Delete all sequences in the database
 $variables['drop_seq_count']         = count($variables['drop_seq_results']) - 1;
 $variables['autorun']                = filter_input(INPUT_POST, 'autorun', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 

--- a/create_universe/40.php
+++ b/create_universe/40.php
@@ -39,9 +39,9 @@ $variables['initbcommod']            = filter_input(INPUT_POST, 'initbcommod', F
 $variables['fedsecs']                = filter_input(INPUT_POST, 'fedsecs', FILTER_SANITIZE_NUMBER_INT);
 $variables['loops']                  = filter_input(INPUT_POST, 'loops', FILTER_SANITIZE_NUMBER_INT);
 $variables['swordfish']              = filter_input(INPUT_POST, 'swordfish', FILTER_SANITIZE_URL);
-$variables['create_seq_results']     = Tki\Schema::createSequences($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::TYPE); // Create all tables in the database
+$variables['create_seq_results']     = Tki\Schema::createSequences($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::DB_TYPE); // Create all tables in the database
 $variables['create_seq_count']       = count($variables['create_seq_results']) - 1;
-$variables['create_tables_results']  = Tki\Schema::createTables($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::TYPE); // Create all tables in the database
+$variables['create_tables_results']  = Tki\Schema::createTables($pdo_db, $pdo_db->prefix, \Tki\SecureConfig::DB_TYPE); // Create all tables in the database
 $variables['create_tables_count']    = count($variables['create_tables_results']) - 1;
 $variables['autorun']                = filter_input(INPUT_POST, 'autorun', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 

--- a/create_universe/80.php
+++ b/create_universe/80.php
@@ -232,7 +232,7 @@ $admin_ip = '1.1.1.1';
 $admin_recovery_time = null;
 $admin_sector = 1;
 $admin_last_login = date("Y-m-d H:i:s");
-$admin_hashed_password = password_hash(\Tki\SecureConfig::ADMINPW, PASSWORD_DEFAULT);
+$admin_hashed_password = password_hash(\Tki\SecureConfig::ADMIN_PASS, PASSWORD_DEFAULT);
 
 $stmt->bindParam(':ship_name', $tkireg->admin_ship_name);
 $stmt->bindParam(':ship_destroyed', $admin_ship_destr);
@@ -253,7 +253,7 @@ $resxx = $stmt->execute();
 $variables['admin_account_results']['result'] = Tki\Db::logDbErrors($pdo_db, $resxx, __LINE__, __FILE__);
 $variables['admin_mail'] = $tkireg->admin_mail;
 $variables['admin_name'] = $tkireg->admin_name;
-$variables['admin_pass'] = \Tki\SecureConfig::ADMINPW;
+$variables['admin_pass'] = \Tki\SecureConfig::ADMIN_PASS;
 $local_table_timer->stop();
 $variables['admin_account_results']['elapsed'] = $local_table_timer->elapsed();
 

--- a/log.php
+++ b/log.php
@@ -53,7 +53,7 @@ if (mb_strlen(trim($swordfish)) === 0)
     $swordfish = false;
 }
 
-if ($swordfish == \Tki\SecureConfig::ADMINPW) // Check if called by admin script
+if ($swordfish == \Tki\SecureConfig::ADMIN_PASS) // Check if called by admin script
 {
     $playerinfo['ship_id'] = $player;
     if ($player == 0)
@@ -313,7 +313,7 @@ $nonext = 0;
 //    $nonext = 0;
 //}
 
-if ($swordfish == \Tki\SecureConfig::ADMINPW) // Fix for admin log view
+if ($swordfish == \Tki\SecureConfig::ADMIN_PASS) // Fix for admin log view
 {
     $postlink = "&swordfish=" . urlencode($swordfish) . "&player=" . urlencode($player);
 }
@@ -362,7 +362,7 @@ else
     echo "&nbsp;&nbsp;&nbsp;";
 }
 
-if ($swordfish == \Tki\SecureConfig::ADMINPW)
+if ($swordfish == \Tki\SecureConfig::ADMIN_PASS)
 {
     echo "<tr><td><td>" .
          "<form accept-charset='utf-8' action=admin.php method=post>" .

--- a/scheduler.php
+++ b/scheduler.php
@@ -88,7 +88,7 @@ else
     }
 }
 
-if ($swordfish != \Tki\SecureConfig::ADMINPW)
+if ($swordfish != \Tki\SecureConfig::ADMIN_PASS)
 {
     echo "<form accept-charset='utf-8' action='scheduler.php' method='post'>";
     echo "Password: <input type='password' name='swordfish' size='20' maxlength='20'><br><br>";

--- a/setup_info.php
+++ b/setup_info.php
@@ -32,6 +32,18 @@ header('Keep-Alive: timeout=15, max=100');         // Ask for persistent HTTP co
 SetCookie('TestCookie', '', 0);
 SetCookie('TestCookie', 'Shuzbutt', time() + 3600, Tki\SetPaths::setGamepath(), $_SERVER['HTTP_HOST']);
 
+/*
+ * Database configuration.
+ * TODO: Move config to .env/array storage.
+ */
+$db_host = \Tki\SecureConfig::DB_HOST;
+$db_port = \Tki\SecureConfig::DB_PORT;
+$db_user = \Tki\SecureConfig::DB_USER;
+$db_pwd = \Tki\SecureConfig::DB_PASS;
+$db_type = \Tki\SecureConfig::DB_TYPE;
+$db_name = \Tki\SecureConfig::DB_NAME;
+$db_prefix = \Tki\SecureConfig::DB_TABLE_PREFIX;
+
 // Database driven language entries
 $langvars = Tki\Translate::load($pdo_db, $lang, array('new', 'login', 'common', 'global_includes', 'global_funcs', 'footer', 'news', 'index', 'options', 'setup_info'));
 

--- a/setup_info.php
+++ b/setup_info.php
@@ -54,14 +54,36 @@ $variables['admin_mail'] = $tkireg->admin_mail;
 $variables['body_class'] = 'tki';
 $variables['template'] = $tkireg->default_template; // Temporarily set the template to the default template until we have a user option
 
+/*
+ * Get the webserver version.
+ * TODO: Clean this up by moving all setup_info logic to a class.
+ */
+$sapi = php_sapi_name();
+$serverType = '';
+$serverVersion = '';
+
+if($sapi === 'apache')
+{
+    $serverType = $sapi;
+    $serverVersion = apache_get_version();
+}
+else
+{
+    // This logic presumes nginx is being used.
+    $nameVersionPair = explode('/', $_SERVER['SERVER_SOFTWARE']);
+    $serverType = $nameVersionPair[0];
+    $serverVersion = array_pop($nameVersionPair);
+}
+
 $variables['selected_lang'] = null;
 $variables['system'] = php_uname();
 $variables['remote_addr'] = $_SERVER['REMOTE_ADDR'];
 $variables['server_addr'] = $_SERVER['HTTP_HOST'] . ':' . $_SERVER['SERVER_PORT'];
 $variables['zend_version'] = zend_version();
-$variables['apache_version'] = apache_get_version();
 $variables['php_version'] = PHP_VERSION;
 $variables['php_sapi_name'] = php_sapi_name();
+$variables['server_type'] = $serverType;
+$variables['server_version'] = $serverVersion;
 $variables['game_path'] = Tki\SetPaths::setGamepath();
 $variables['db_type'] = $db_type;
 $variables['db_name'] = $db_name;

--- a/templates/classic/setup_info.tpl
+++ b/templates/classic/setup_info.tpl
@@ -163,8 +163,12 @@ This information will help us to help you much faster and will help improve our 
       <td width="75%" colspan="2" bgcolor="#C0C0C0" align="left" valign="top"><font color="#000">{$variables['zend_version']}</font></td>
     </tr>
     <tr>
-      <td width="25%" bgcolor="#ccccff" align="left" valign="top"><font color="#000">apache_version</font></td>
-      <td width="75%" colspan="2" bgcolor="#C0C0C0" align="left" valign="top"><font color="#000">{$variables['apache_version']}</font></td>
+      <td width="25%" bgcolor="#ccccff" align="left" valign="top"><font color="#000">server_type</font></td>
+      <td width="75%" colspan="2" bgcolor="#C0C0C0" align="left" valign="top"><font color="#000">{$variables['server_type']}</font></td>
+    </tr>
+    <tr>
+      <td width="25%" bgcolor="#ccccff" align="left" valign="top"><font color="#000">server_version</font></td>
+      <td width="75%" colspan="2" bgcolor="#C0C0C0" align="left" valign="top"><font color="#000">{$variables['server_version']}</font></td>
     </tr>
     <tr>
       <td width="25%" bgcolor="#ccccff" align="left" valign="top"><font color="#000">php_version</font></td>

--- a/xenobe_control.php
+++ b/xenobe_control.php
@@ -48,7 +48,7 @@ if (mb_strlen(trim($swordfish)) === 0)
     $swordfish = false;
 }
 
-if ($swordfish != \Tki\SecureConfig::ADMINPW)
+if ($swordfish != \Tki\SecureConfig::ADMIN_PASS)
 {
     echo "<form accept-charset='utf-8' action=xenobe_control.php method=post>";
     echo "password: <input type=password name=swordfish size=20><br><br>";


### PR DESCRIPTION
This wraps the call to `apache_get_version()` in a check to see if `apache` is being used, and falls back to providing information on what version of `nginx` is being used if apache isn't. 

#### Files to inspect:
- `/setup_info.php`
- `/templates/classic/setup_info.tpl`

#### Notes:
- Depends on #27 being merged first so this PR can be rebased.
- A call to `$_SERVER['SERVER_SOFTWARE']` is being made. This should be cleaned up when we impliment a class to wrap around `$_SERVER` & `$_SESSION`.